### PR TITLE
fix: housekeeping — data integrity, NaN inputs, display names, unused dep

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,6 @@
       "version": "0.1.0",
       "dependencies": {
         "@dnd-kit/core": "^6.1.0",
-        "@dnd-kit/sortable": "^8.0.0",
         "@tauri-apps/api": "^2.10.1",
         "leaflet": "^1.9.4",
         "react": "^18.3.1",
@@ -350,20 +349,6 @@
       "peerDependencies": {
         "react": ">=16.8.0",
         "react-dom": ">=16.8.0"
-      }
-    },
-    "node_modules/@dnd-kit/sortable": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/@dnd-kit/sortable/-/sortable-8.0.0.tgz",
-      "integrity": "sha512-U3jk5ebVXe1Lr7c2wU7SBZjcWdQP+j7peHJfCspnA81enlu88Mgd7CC8Q+pub9ubP7eKVETzJW+IBAhsqbSu/g==",
-      "license": "MIT",
-      "dependencies": {
-        "@dnd-kit/utilities": "^3.2.2",
-        "tslib": "^2.0.0"
-      },
-      "peerDependencies": {
-        "@dnd-kit/core": "^6.1.0",
-        "react": ">=16.8.0"
       }
     },
     "node_modules/@dnd-kit/utilities": {

--- a/package.json
+++ b/package.json
@@ -11,7 +11,6 @@
   },
   "dependencies": {
     "@dnd-kit/core": "^6.1.0",
-    "@dnd-kit/sortable": "^8.0.0",
     "@tauri-apps/api": "^2.10.1",
     "leaflet": "^1.9.4",
     "react": "^18.3.1",

--- a/src/components/BedCanvas.tsx
+++ b/src/components/BedCanvas.tsx
@@ -174,8 +174,8 @@ export function AddBedForm() {
         const data = new FormData(form);
         addBed({
           name: String(data.get("name") || "New Bed"),
-          widthFt: Number(data.get("widthFt") || 4),
-          lengthFt: Number(data.get("lengthFt") || 8),
+          widthFt: Math.min(20, Math.max(1, Number(data.get("widthFt")) || 4)),
+          lengthFt: Math.min(30, Math.max(1, Number(data.get("lengthFt")) || 8)),
           sun: (data.get("sun") as Bed["sun"]) || "full",
         });
         form.reset();

--- a/src/components/PlantCatalog.tsx
+++ b/src/components/PlantCatalog.tsx
@@ -1,6 +1,6 @@
 import { useMemo, useState } from "react";
 import { useDraggable } from "@dnd-kit/core";
-import { PLANTS } from "../data/plants";
+import { PLANTS, PLANT_BY_ID } from "../data/plants";
 import type { Plant, PlantCategory } from "../types";
 
 const CATEGORIES: (PlantCategory | "all")[] = [
@@ -80,13 +80,13 @@ function PlantDetail({ plant, onClose }: { plant: Plant; onClose: () => void }) 
       {plant.companions.length > 0 && (
         <div className="text-xs">
           <span className="text-leaf-700 font-medium">Plant with: </span>
-          {plant.companions.join(", ")}
+          {plant.companions.map((id) => PLANT_BY_ID.get(id)?.name ?? id).join(", ")}
         </div>
       )}
       {plant.antagonists.length > 0 && (
         <div className="text-xs">
           <span className="text-red-700 font-medium">Keep away from: </span>
-          {plant.antagonists.join(", ")}
+          {plant.antagonists.map((id) => PLANT_BY_ID.get(id)?.name ?? id).join(", ")}
         </div>
       )}
       {plant.notes && (

--- a/src/data/plants.ts
+++ b/src/data/plants.ts
@@ -43,7 +43,7 @@ export const PLANTS: Plant[] = [
     sun: "full",
     spacingInches: 12,
     daysToMaturity: 90,
-    companions: ["bean-bush", "cabbage", "corn", "marigold", "horseradish"],
+    companions: ["bean-bush", "cabbage", "corn", "marigold"],
     antagonists: ["tomato", "cucumber", "squash", "pumpkin", "sunflower"],
   },
   {
@@ -54,7 +54,7 @@ export const PLANTS: Plant[] = [
     sun: "full",
     spacingInches: 18,
     daysToMaturity: 70,
-    companions: ["onion", "garlic", "dill", "beet", "chamomile", "potato", "celery"],
+    companions: ["onion", "garlic", "dill", "beet", "potato", "celery"],
     antagonists: ["tomato", "strawberry", "bean-pole"],
   },
   {

--- a/src/data/plants.ts
+++ b/src/data/plants.ts
@@ -484,3 +484,13 @@ export const PLANTS: Plant[] = [
 ];
 
 export const PLANT_BY_ID = new Map(PLANTS.map((p) => [p.id, p]));
+
+if (import.meta.env.DEV) {
+  for (const plant of PLANTS) {
+    for (const id of [...plant.companions, ...plant.antagonists]) {
+      if (!PLANT_BY_ID.has(id)) {
+        console.warn(`[plants] Unknown ID "${id}" in ${plant.id} companions/antagonists`);
+      }
+    }
+  }
+}

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />


### PR DESCRIPTION
## Summary

- **#15** Remove `@dnd-kit/sortable` — only `@dnd-kit/core` is actually used in the codebase
- **#14** Drop dangling companion IDs `horseradish` (potato) and `chamomile` (cabbage) that had no corresponding plant entries, causing silent `PLANT_BY_ID.get()` failures
- **#9** Clamp bed `widthFt`/`lengthFt` to their `min`/`max` bounds and fall back to defaults so an empty input never produces `NaN` in the grid layout
- **#11** Resolve companion/antagonist IDs to display names in `PlantDetail` instead of showing raw kebab-case IDs (`bean-bush` → `Bush Bean`)

## Test plan

- [ ] Add a bed, clear the width field, submit — should default to 4 ft (no broken grid)
- [ ] Click a plant in the catalog and confirm companions show human-readable names
- [ ] Confirm potato shows no `horseradish` companion; cabbage shows no `chamomile`
- [ ] `npm run build` passes cleanly (no `@dnd-kit/sortable` import errors)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)