### PR TITLE
fix: state & performance — persist version, scoped subscriptions, map recenter

### DIFF
--- a/src/components/BedCanvas.tsx
+++ b/src/components/BedCanvas.tsx
@@ -1,4 +1,5 @@
 import { useDroppable, useDraggable } from "@dnd-kit/core";
+import { useShallow } from "zustand/react/shallow";
 import { useGarden } from "../store";
 import { PLANT_BY_ID } from "../data/plants";
 import type { Bed, Placement } from "../types";
@@ -107,10 +108,11 @@ function GridCell({
 }
 
 export function BedView({ bed }: { bed: Bed }) {
-  const placements = useGarden((s) => s.placements);
+  const inBed = useGarden(
+    useShallow((s) => s.placements.filter((p) => p.bedId === bed.id)),
+  );
   const removeBed = useGarden((s) => s.removeBed);
   const updateBed = useGarden((s) => s.updateBed);
-  const inBed = placements.filter((p) => p.bedId === bed.id);
 
   const cols = Math.max(1, Math.round(bed.widthFt));
   const rows = Math.max(1, Math.round(bed.lengthFt));

--- a/src/components/LocationPanel.tsx
+++ b/src/components/LocationPanel.tsx
@@ -29,11 +29,11 @@ function ClickToPlace({ onPick }: { onPick: (lat: number, lon: number) => void }
   return null;
 }
 
-function RecenterMap({ lat, lon, zoom }: { lat: number; lon: number; zoom?: number }) {
+function RecenterMap({ lat, lon }: { lat: number; lon: number }) {
   const map = useMap();
   useEffect(() => {
-    map.setView([lat, lon], zoom ?? map.getZoom());
-  }, [lat, lon, zoom, map]);
+    map.setView([lat, lon], map.getZoom());
+  }, [lat, lon, map]);
   return null;
 }
 

--- a/src/components/LocationPanel.tsx
+++ b/src/components/LocationPanel.tsx
@@ -1,5 +1,5 @@
-import { useState } from "react";
-import { MapContainer, TileLayer, Marker, useMapEvents } from "react-leaflet";
+import { useEffect, useState } from "react";
+import { MapContainer, TileLayer, Marker, useMap, useMapEvents } from "react-leaflet";
 import L from "leaflet";
 import "leaflet/dist/leaflet.css";
 import { useGarden } from "../store";
@@ -26,6 +26,14 @@ function ClickToPlace({ onPick }: { onPick: (lat: number, lon: number) => void }
       onPick(e.latlng.lat, e.latlng.lng);
     },
   });
+  return null;
+}
+
+function RecenterMap({ lat, lon, zoom }: { lat: number; lon: number; zoom?: number }) {
+  const map = useMap();
+  useEffect(() => {
+    map.setView([lat, lon], zoom ?? map.getZoom());
+  }, [lat, lon, zoom, map]);
   return null;
 }
 
@@ -70,7 +78,10 @@ export function LocationPanel() {
           />
           <ClickToPlace onPick={onPick} />
           {draft.lat != null && draft.lon != null && (
-            <Marker position={[draft.lat, draft.lon]} icon={markerIcon} />
+            <>
+              <Marker position={[draft.lat, draft.lon]} icon={markerIcon} />
+              <RecenterMap lat={draft.lat} lon={draft.lon} />
+            </>
           )}
         </MapContainer>
         {draft.lat != null && draft.lon != null && (

--- a/src/store.ts
+++ b/src/store.ts
@@ -87,6 +87,9 @@ export const useGarden = create<GardenState & Actions>()(
       name: STORAGE_KEY,
       version: 1,
       migrate: (persisted, version) => {
+        // v0 → v1: no schema changes; pass through unchanged.
+        // Future migrations should set new required fields explicitly
+        // rather than relying on the GardenState cast.
         if (version === 0) return persisted as GardenState;
         return persisted as GardenState;
       },

--- a/src/store.ts
+++ b/src/store.ts
@@ -83,6 +83,13 @@ export const useGarden = create<GardenState & Actions>()(
         })),
       resetGarden: () => set(initial),
     }),
-    { name: STORAGE_KEY },
+    {
+      name: STORAGE_KEY,
+      version: 1,
+      migrate: (persisted, version) => {
+        if (version === 0) return persisted as GardenState;
+        return persisted as GardenState;
+      },
+    },
   ),
 );


### PR DESCRIPTION
## Summary

- **#17** Add `version: 1` and a `migrate` function to the Zustand persist config in `store.ts`. Existing un-versioned (v0) state passes through unchanged so users don't lose data; the scaffold is in place to write real migrations the next time the schema changes.
- **#13** Replace `BedView`'s full-placements subscription with a `useShallow` selector that returns only placements for the current bed. A change in bed A no longer re-renders all the other `BedView` components, and `inBed.filter(...)` no longer runs on every unrelated render.
- **#10** Add a `RecenterMap` child component that calls `map.setView([lat, lon], currentZoom)` whenever the draft pin coordinates change. `MapContainer`'s `center`/`zoom` props are uncontrolled after mount, so loading saved coordinates from the store or programmatically jumping the pin now actually moves the map. Current zoom is preserved so user clicks don't re-zoom them out.

## Test plan

- [ ] **Migration** — load app with existing v0 state in localStorage; data persists, no errors. Bump `version` to 2 in store.ts in a follow-up to confirm migrate is wired up correctly when needed.
- [ ] **BedView re-renders** — open React DevTools Profiler with two beds present; placing a plant in bed A should only re-render the bed-A `BedView`, not bed B.
- [ ] **Map recenter** — save a location with a pin, refresh the page, navigate back to the Location tab; map should be centered on the saved pin (not the default center of the US).
- [ ] **Map preserves zoom on click** — zoom in to a city level, click the map; the marker drops at the click point and the zoom doesn't reset.
- [ ] `npm run build` passes; type check clean.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)