### PR TITLE
feat: sun mismatch warnings and calendar year-boundary fix

### DIFF
--- a/src/components/BedCanvas.tsx
+++ b/src/components/BedCanvas.tsx
@@ -2,17 +2,19 @@ import { useDroppable, useDraggable } from "@dnd-kit/core";
 import { useShallow } from "zustand/react/shallow";
 import { useGarden } from "../store";
 import { PLANT_BY_ID } from "../data/plants";
-import type { Bed, Placement } from "../types";
+import type { Bed, Placement, SunRequirement } from "../types";
 import { placementVerdict } from "../lib/companions";
+import { sunCompatible } from "../lib/sun";
 import { clampBedDimension } from "../lib/bed";
 
 const SUN_ICON = { full: "☀️", partial: "⛅", shade: "🌥" } as const;
 
-const VERDICT_RING = {
-  synergy: "ring-2 ring-leaf-500",
+const RING_BY_KIND = {
   conflict: "ring-2 ring-red-500",
+  sunWarning: "ring-2 ring-amber-500",
+  synergy: "ring-2 ring-leaf-500",
   neutral: "ring-1 ring-stone-300",
-};
+} as const;
 
 function plantSwatch(plantId: string): string {
   const plant = PLANT_BY_ID.get(plantId);
@@ -36,14 +38,31 @@ function plantSwatch(plantId: string): string {
 function PlantedCell({
   placement,
   allPlacements,
+  bedSun,
   onRemove,
 }: {
   placement: Placement;
   allPlacements: Placement[];
+  bedSun: SunRequirement;
   onRemove: () => void;
 }) {
   const plant = PLANT_BY_ID.get(placement.plantId);
   const verdict = placementVerdict(placement, allPlacements);
+  const sunMismatch = plant ? !sunCompatible(plant.sun, bedSun) : false;
+  const ringKind =
+    verdict === "conflict"
+      ? "conflict"
+      : sunMismatch
+        ? "sunWarning"
+        : verdict === "synergy"
+          ? "synergy"
+          : "neutral";
+  const titleSuffix = [
+    verdict !== "neutral" ? verdict : null,
+    sunMismatch ? `needs ${plant?.sun} sun` : null,
+  ]
+    .filter(Boolean)
+    .join(", ");
   const { attributes, listeners, setNodeRef, isDragging } = useDraggable({
     id: `placement:${placement.id}`,
     data: { source: "placement", placementId: placement.id },
@@ -54,14 +73,14 @@ function PlantedCell({
       {...listeners}
       {...attributes}
       title={`${plant?.name ?? placement.plantId}${
-        verdict !== "neutral" ? ` — ${verdict}` : ""
+        titleSuffix ? ` — ${titleSuffix}` : ""
       } (right-click to remove)`}
       onContextMenu={(e) => {
         e.preventDefault();
         onRemove();
       }}
       className={`absolute inset-0.5 rounded flex items-center justify-center text-lg bg-white cursor-grab ${
-        VERDICT_RING[verdict]
+        RING_BY_KIND[ringKind]
       } ${isDragging ? "opacity-50" : ""}`}
     >
       <span aria-hidden>{plantSwatch(placement.plantId)}</span>
@@ -71,11 +90,13 @@ function PlantedCell({
 
 function GridCell({
   bedId,
+  bedSun,
   row,
   col,
   placements,
 }: {
   bedId: string;
+  bedSun: SunRequirement;
   row: number;
   col: number;
   placements: Placement[];
@@ -101,6 +122,7 @@ function GridCell({
         <PlantedCell
           placement={occupant}
           allPlacements={placements}
+          bedSun={bedSun}
           onRemove={() => removePlacement(occupant.id)}
         />
       )}
@@ -154,6 +176,7 @@ export function BedView({ bed }: { bed: Bed }) {
             <GridCell
               key={`${row}-${col}`}
               bedId={bed.id}
+              bedSun={bed.sun}
               row={row}
               col={col}
               placements={inBed}

--- a/src/components/CalendarView.tsx
+++ b/src/components/CalendarView.tsx
@@ -3,7 +3,7 @@ import { useShallow } from "zustand/react/shallow";
 import { useGarden } from "../store";
 import { PLANT_BY_ID } from "../data/plants";
 import { parseFrostDate } from "../data/zones";
-import { computeWindows, monthLabel, type TimingWindow } from "../lib/calendar";
+import { computeWindows, monthLabel, targetCalendarYear, type TimingWindow } from "../lib/calendar";
 
 const KIND_LABEL: Record<TimingWindow["kind"], string> = {
   startIndoors: "Start indoors",
@@ -25,10 +25,10 @@ export function CalendarView() {
     useShallow((s) => Array.from(new Set(s.placements.map((p) => p.plantId)))),
   );
 
-  const lastFrost = parseFrostDate(location.lastFrost);
-  const firstFrost = parseFrostDate(location.firstFrost);
+  const year = targetCalendarYear(new Date(), location.firstFrost);
+  const lastFrost = parseFrostDate(location.lastFrost, year);
+  const firstFrost = parseFrostDate(location.firstFrost, year);
 
-  const year = lastFrost?.getFullYear() ?? new Date().getFullYear();
   const yearStart = new Date(year, 0, 1).getTime();
   const yearEnd = new Date(year + 1, 0, 1).getTime();
   const yearMs = yearEnd - yearStart;

--- a/src/components/IssuesPanel.tsx
+++ b/src/components/IssuesPanel.tsx
@@ -1,5 +1,6 @@
 import { useGarden } from "../store";
 import { allIssues } from "../lib/companions";
+import { sunCompatible } from "../lib/sun";
 import { PLANT_BY_ID } from "../data/plants";
 import { useMemo } from "react";
 
@@ -7,6 +8,17 @@ export function IssuesPanel() {
   const placements = useGarden((s) => s.placements);
   const beds = useGarden((s) => s.beds);
   const issues = useMemo(() => allIssues(placements), [placements]);
+
+  const sunMismatches = useMemo(() => {
+    const bedSun = new Map(beds.map((b) => [b.id, b.sun]));
+    return placements.flatMap((p) => {
+      const plant = PLANT_BY_ID.get(p.plantId);
+      const bs = bedSun.get(p.bedId);
+      if (!plant || !bs) return [];
+      if (sunCompatible(plant.sun, bs)) return [];
+      return [{ placementId: p.id, bedId: p.bedId, plantId: p.plantId, plantSun: plant.sun, bedSun: bs }];
+    });
+  }, [placements, beds]);
 
   if (placements.length === 0) {
     return (
@@ -24,14 +36,35 @@ export function IssuesPanel() {
 
   return (
     <div className="space-y-3 text-sm">
-      <div className="flex gap-3 text-xs">
+      <div className="flex flex-wrap gap-3 text-xs">
         <span className="rounded-full bg-leaf-100 text-leaf-800 px-2 py-0.5">
           {synergies.length} synergies
         </span>
         <span className="rounded-full bg-red-100 text-red-800 px-2 py-0.5">
           {conflicts.length} conflicts
         </span>
+        <span className="rounded-full bg-amber-100 text-amber-800 px-2 py-0.5">
+          {sunMismatches.length} sun mismatches
+        </span>
       </div>
+
+      {sunMismatches.length > 0 && (
+        <div>
+          <div className="font-medium text-amber-800 mb-1">Sun mismatches</div>
+          <ul className="space-y-1">
+            {sunMismatches.map((s) => (
+              <li
+                key={s.placementId}
+                className="rounded border border-amber-200 bg-amber-50 px-2 py-1"
+              >
+                <span className="font-medium">{plantName(s.plantId)}</span> needs{" "}
+                {s.plantSun} sun but{" "}
+                <span className="text-stone-600">{bedName(s.bedId)}</span> is {s.bedSun}
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
 
       {conflicts.length > 0 && (
         <div>
@@ -74,7 +107,7 @@ export function IssuesPanel() {
         </div>
       )}
 
-      {conflicts.length === 0 && synergies.length === 0 && (
+      {conflicts.length === 0 && synergies.length === 0 && sunMismatches.length === 0 && (
         <div className="text-stone-500">No notable interactions yet.</div>
       )}
     </div>

--- a/src/lib/calendar.test.ts
+++ b/src/lib/calendar.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect } from "vitest";
+import { targetCalendarYear, computeWindows } from "./calendar";
+import type { Plant } from "../types";
+
+describe("targetCalendarYear", () => {
+  it("returns the current year when today is before first frost", () => {
+    const today = new Date("2026-04-15");
+    expect(targetCalendarYear(today, "Oct 30")).toBe(2026);
+  });
+
+  it("returns next year when today is after first frost", () => {
+    const today = new Date("2026-11-15");
+    expect(targetCalendarYear(today, "Oct 30")).toBe(2027);
+  });
+
+  it("returns current year when first frost is undefined", () => {
+    const today = new Date("2026-11-15");
+    expect(targetCalendarYear(today, undefined)).toBe(2026);
+  });
+
+  it('returns current year when first frost is "none" (tropical zone)', () => {
+    const today = new Date("2026-11-15");
+    expect(targetCalendarYear(today, "none")).toBe(2026);
+  });
+
+  it('returns current year when first frost is "rare"', () => {
+    const today = new Date("2026-11-15");
+    expect(targetCalendarYear(today, "rare")).toBe(2026);
+  });
+
+  it("treats the day of first frost as start of next season", () => {
+    // parseFrostDate("Oct 30") yields Oct 30 at midnight. Anything later
+    // that same day already counts as past frost.
+    const today = new Date("2026-10-30T12:00:00");
+    expect(targetCalendarYear(today, "Oct 30")).toBe(2027);
+  });
+
+  it("returns current year on the day before first frost", () => {
+    const today = new Date("2026-10-29T23:00:00");
+    expect(targetCalendarYear(today, "Oct 30")).toBe(2026);
+  });
+});
+
+describe("computeWindows", () => {
+  const lastFrost = new Date("2026-04-15");
+  const firstFrost = new Date("2026-10-30");
+
+  it("returns no windows for a plant without timing", () => {
+    const plant: Plant = {
+      id: "x",
+      name: "X",
+      category: "vegetable",
+      sun: "full",
+      spacingInches: 12,
+      companions: [],
+      antagonists: [],
+    };
+    expect(computeWindows(plant, lastFrost, firstFrost)).toEqual([]);
+  });
+
+  it("derives start-indoors and transplant windows for tomato-like plants", () => {
+    const plant: Plant = {
+      id: "tomato",
+      name: "Tomato",
+      category: "vegetable",
+      sun: "full",
+      spacingInches: 24,
+      daysToMaturity: 75,
+      companions: [],
+      antagonists: [],
+      timing: {
+        startIndoorsWeeksBeforeLastFrost: 6,
+        transplantWeeksAfterLastFrost: 2,
+      },
+    };
+    const windows = computeWindows(plant, lastFrost, firstFrost);
+    const kinds = windows.map((w) => w.kind);
+    expect(kinds).toContain("startIndoors");
+    expect(kinds).toContain("transplant");
+    expect(kinds).toContain("harvest");
+  });
+
+  it("uses first frost as harvest end when harvestableThroughFirstFrost is set", () => {
+    const plant: Plant = {
+      id: "kale",
+      name: "Kale",
+      category: "vegetable",
+      sun: "full",
+      spacingInches: 18,
+      daysToMaturity: 55,
+      companions: [],
+      antagonists: [],
+      timing: {
+        transplantWeeksAfterLastFrost: -2,
+        harvestableThroughFirstFrost: true,
+      },
+    };
+    const windows = computeWindows(plant, lastFrost, firstFrost);
+    const harvest = windows.find((w) => w.kind === "harvest");
+    expect(harvest?.end.getTime()).toBe(firstFrost.getTime());
+  });
+});

--- a/src/lib/calendar.ts
+++ b/src/lib/calendar.ts
@@ -1,4 +1,5 @@
 import type { Plant } from "../types";
+import { parseFrostDate } from "../data/zones";
 
 export type TimingWindow = {
   kind: "startIndoors" | "transplant" | "directSow" | "harvest";
@@ -63,4 +64,16 @@ export function computeWindows(
 
 export function monthLabel(d: Date): string {
   return d.toLocaleString("en-US", { month: "short" });
+}
+
+export function targetCalendarYear(
+  today: Date,
+  firstFrost: string | undefined,
+): number {
+  const currentYear = today.getFullYear();
+  const thisYearsFirstFrost = parseFrostDate(firstFrost, currentYear);
+  if (thisYearsFirstFrost && today > thisYearsFirstFrost) {
+    return currentYear + 1;
+  }
+  return currentYear;
 }

--- a/src/lib/sun.test.ts
+++ b/src/lib/sun.test.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect } from "vitest";
+import { sunCompatible } from "./sun";
+
+describe("sunCompatible", () => {
+  it("full-sun bed accommodates any plant", () => {
+    expect(sunCompatible("full", "full")).toBe(true);
+    expect(sunCompatible("partial", "full")).toBe(true);
+    expect(sunCompatible("shade", "full")).toBe(true);
+  });
+
+  it("partial-sun bed warns on full-sun plants", () => {
+    expect(sunCompatible("full", "partial")).toBe(false);
+    expect(sunCompatible("partial", "partial")).toBe(true);
+    expect(sunCompatible("shade", "partial")).toBe(true);
+  });
+
+  it("shade bed warns on anything that needs more than shade", () => {
+    expect(sunCompatible("full", "shade")).toBe(false);
+    expect(sunCompatible("partial", "shade")).toBe(false);
+    expect(sunCompatible("shade", "shade")).toBe(true);
+  });
+});

--- a/src/lib/sun.ts
+++ b/src/lib/sun.ts
@@ -1,0 +1,10 @@
+import type { SunRequirement } from "../types";
+
+const RANK: Record<SunRequirement, number> = { full: 2, partial: 1, shade: 0 };
+
+export function sunCompatible(
+  plantSun: SunRequirement,
+  bedSun: SunRequirement,
+): boolean {
+  return RANK[bedSun] >= RANK[plantSun];
+}


### PR DESCRIPTION
## Summary

Two small features bundled because both are pure logic, both ship with full Vitest coverage, and neither touches infrastructure. Total non-test diff is ~120 lines.

### #3 — Sun-requirement warnings

- **`src/lib/sun.ts`** — `sunCompatible(plantSun, bedSun)` using a numeric ranking (full=2, partial=1, shade=0). Bed is compatible iff `bed rank >= plant rank`.
- **`BedCanvas`** threads `bed.sun` through `GridCell` to `PlantedCell`. Mismatched cells get an amber-500 ring. **Ring priority** is `conflict` (red) > `sunWarning` (amber) > `synergy` (green) > `neutral` so the most actionable issue stays visible. Tooltip text now mentions both verdicts ("synergy, needs full sun").
- **`IssuesPanel`** adds a "Sun mismatches" section listing each placement with the bed name and what the plant needs vs what the bed provides. The summary chips now include a new amber "X sun mismatches" pill.
- **3 unit tests** covering all 9 `(plant × bed)` combinations.

### #25 — Calendar year-boundary

- **`targetCalendarYear(today, firstFrost)`** in `src/lib/calendar.ts` returns next year once today has passed this year's first frost. Tropical zones (`firstFrost = "none" / "rare" / undefined`) keep current year because `parseFrostDate` returns `null`.
- **`CalendarView`** now derives the year before parsing frost dates, so opening the app in November shows next year's planting windows instead of the just-ended season.
- **6 unit tests** for `targetCalendarYear` (pre-frost, post-frost, tropical, "rare", on-frost-day, day-before-frost) + **3 quick coverage tests** for `computeWindows` (no-timing, tomato-like derivations, kale-like harvest-through-first-frost).

## Test plan

- [x] `npm test` — 27/27 pass (4 test files)
- [x] `npm run build` — clean
- [x] `npx tsc --noEmit` — clean
- [ ] Place a full-sun plant (tomato) in a partial-sun bed; cell should get amber ring; IssuesPanel should list the mismatch
- [ ] Verify a conflict (e.g. tomato + cabbage) keeps its red ring even when the bed sun is wrong — conflict trumps sun warning
- [ ] Open Calendar tab today (April 2026); year should show 2026
- [ ] Manually set system clock to November 2026, reopen Calendar; year should show 2027

🤖 Generated with [Claude Code](https://claude.ai/claude-code)