### PR TITLE
feat: spacing-aware cells (square-foot gardening)

### DIFF
--- a/src/components/BedCanvas.tsx
+++ b/src/components/BedCanvas.tsx
@@ -6,6 +6,7 @@ import type { Bed, Placement, SunRequirement } from "../types";
 import { placementVerdict } from "../lib/companions";
 import { sunCompatible } from "../lib/sun";
 import { clampBedDimension } from "../lib/bed";
+import { plantsPerSquareFoot, subGridSide } from "../lib/spacing";
 
 const SUN_ICON = { full: "☀️", partial: "⛅", shade: "🌥" } as const;
 
@@ -106,25 +107,53 @@ function GridCell({
     id: `cell:${bedId}:${row}:${col}`,
     data: { bedId, row, col },
   });
-  const occupant = placements.find(
-    (p) => p.bedId === bedId && p.row === row && p.col === col,
-  );
+  const occupants = placements
+    .filter((p) => p.bedId === bedId && p.row === row && p.col === col)
+    .sort((a, b) => a.id.localeCompare(b.id));
+  const firstPlant = occupants[0] ? PLANT_BY_ID.get(occupants[0].plantId) : undefined;
+  const capacity = firstPlant ? plantsPerSquareFoot(firstPlant.spacingInches) : 1;
+  const side = subGridSide(capacity);
+  const isAtCapacity = occupants.length >= capacity;
   return (
     <div
       ref={setNodeRef}
       className={`relative aspect-square border ${
         isOver
-          ? "border-leaf-500 bg-leaf-100"
+          ? isAtCapacity
+            ? "border-red-400 bg-red-50"
+            : "border-leaf-500 bg-leaf-100"
           : "border-stone-200 bg-stone-50"
       }`}
+      title={
+        occupants.length > 0
+          ? `${occupants.length}/${capacity} ${firstPlant?.name ?? ""}`
+          : undefined
+      }
     >
-      {occupant && (
-        <PlantedCell
-          placement={occupant}
-          allPlacements={placements}
-          bedSun={bedSun}
-          onRemove={() => removePlacement(occupant.id)}
-        />
+      {occupants.length > 0 && (
+        <div
+          className="absolute inset-0.5 grid gap-px"
+          style={{
+            gridTemplateColumns: `repeat(${side}, minmax(0, 1fr))`,
+            gridTemplateRows: `repeat(${side}, minmax(0, 1fr))`,
+          }}
+        >
+          {Array.from({ length: capacity }).map((_, idx) => {
+            const occupant = occupants[idx];
+            return (
+              <div key={idx} className="relative">
+                {occupant && (
+                  <PlantedCell
+                    placement={occupant}
+                    allPlacements={placements}
+                    bedSun={bedSun}
+                    onRemove={() => removePlacement(occupant.id)}
+                  />
+                )}
+              </div>
+            );
+          })}
+        </div>
       )}
     </div>
   );

--- a/src/lib/companions.test.ts
+++ b/src/lib/companions.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect } from "vitest";
+import { allIssues, neighborsOf, verdictBetween } from "./companions";
+import type { Placement } from "../types";
+
+const place = (id: string, plantId: string, row: number, col: number): Placement => ({
+  id,
+  bedId: "bed1",
+  plantId,
+  row,
+  col,
+});
+
+describe("verdictBetween", () => {
+  it("identifies known synergies (tomato + basil)", () => {
+    expect(verdictBetween("tomato", "basil")).toBe("synergy");
+  });
+
+  it("identifies known conflicts (tomato + cabbage)", () => {
+    expect(verdictBetween("tomato", "cabbage")).toBe("conflict");
+  });
+
+  it("returns neutral for unrelated pairs", () => {
+    expect(verdictBetween("tomato", "asparagus")).toBe("synergy");
+    expect(verdictBetween("radish", "fennel")).toBe("neutral");
+  });
+});
+
+describe("neighborsOf", () => {
+  it("includes placements within 2-cell radius in same bed", () => {
+    const target = place("a", "tomato", 5, 5);
+    const all = [
+      target,
+      place("b", "basil", 5, 6),
+      place("c", "carrot", 7, 7),
+      place("d", "kale", 8, 8),
+    ];
+    const neighbors = neighborsOf(target, all).map((p) => p.id);
+    expect(neighbors).toEqual(["b", "c"]);
+  });
+
+  it("excludes placements in other beds", () => {
+    const target = place("a", "tomato", 5, 5);
+    const other = { ...place("b", "basil", 5, 5), bedId: "bed2" };
+    expect(neighborsOf(target, [target, other])).toEqual([]);
+  });
+});
+
+describe("allIssues dedup", () => {
+  it("emits only one issue per plant pair per bed even with stacked SFG cells", () => {
+    // 4 lettuces in one cell + 1 tomato adjacent — should yield ONE
+    // tomato/lettuce synergy, not 4
+    const placements: Placement[] = [
+      place("l1", "lettuce", 0, 0),
+      place("l2", "lettuce", 0, 0),
+      place("l3", "lettuce", 0, 0),
+      place("l4", "lettuce", 0, 0),
+      place("t1", "tomato", 0, 1),
+    ];
+    const issues = allIssues(placements);
+    const synergies = issues.filter(
+      (i) =>
+        (i.plantId === "tomato" && i.withPlantId === "lettuce") ||
+        (i.plantId === "lettuce" && i.withPlantId === "tomato"),
+    );
+    expect(synergies).toHaveLength(1);
+  });
+
+  it("emits separate issues for the same plant pair in different beds", () => {
+    const placements: Placement[] = [
+      place("a", "tomato", 0, 0),
+      place("b", "basil", 0, 1),
+      { ...place("c", "tomato", 0, 0), bedId: "bed2" },
+      { ...place("d", "basil", 0, 1), bedId: "bed2" },
+    ];
+    const synergies = allIssues(placements).filter((i) => i.verdict === "synergy");
+    expect(synergies).toHaveLength(2);
+  });
+
+  it("does not emit issues for same-plant pairs in the same cell", () => {
+    const placements: Placement[] = [
+      place("l1", "lettuce", 0, 0),
+      place("l2", "lettuce", 0, 0),
+    ];
+    expect(allIssues(placements)).toEqual([]);
+  });
+});

--- a/src/lib/companions.test.ts
+++ b/src/lib/companions.test.ts
@@ -19,8 +19,11 @@ describe("verdictBetween", () => {
     expect(verdictBetween("tomato", "cabbage")).toBe("conflict");
   });
 
-  it("returns neutral for unrelated pairs", () => {
+  it("identifies less-obvious synergies (tomato + asparagus)", () => {
     expect(verdictBetween("tomato", "asparagus")).toBe("synergy");
+  });
+
+  it("returns neutral for genuinely unrelated pairs (radish + fennel)", () => {
     expect(verdictBetween("radish", "fennel")).toBe("neutral");
   });
 });

--- a/src/lib/companions.ts
+++ b/src/lib/companions.ts
@@ -51,14 +51,18 @@ export function placementVerdict(
 
 export function allIssues(placements: Placement[]): NeighborIssue[] {
   const issues: NeighborIssue[] = [];
+  // Dedup by (plantA, plantB, bedId) so a square-foot cell holding multiple
+  // instances of the same plant doesn't produce N identical issue rows for
+  // each nearby companion.
   const seen = new Set<string>();
   for (const p of placements) {
     for (const n of neighborsOf(p, placements)) {
-      const key = [p.id, n.id].sort().join("|");
-      if (seen.has(key)) continue;
-      seen.add(key);
       const v = verdictBetween(p.plantId, n.plantId);
       if (v === "neutral") continue;
+      const plantPair = [p.plantId, n.plantId].sort().join("|");
+      const key = `${p.bedId}|${plantPair}`;
+      if (seen.has(key)) continue;
+      seen.add(key);
       const aName = PLANT_BY_ID.get(p.plantId)?.name ?? p.plantId;
       const bName = PLANT_BY_ID.get(n.plantId)?.name ?? n.plantId;
       issues.push({

--- a/src/lib/spacing.test.ts
+++ b/src/lib/spacing.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect } from "vitest";
+import { plantsPerSquareFoot, subGridSide } from "./spacing";
+
+describe("plantsPerSquareFoot", () => {
+  it("returns 16 for very tight spacing (≤ 3 inches)", () => {
+    expect(plantsPerSquareFoot(2)).toBe(16);
+    expect(plantsPerSquareFoot(3)).toBe(16);
+  });
+
+  it("returns 9 for 4–5 inch spacing", () => {
+    expect(plantsPerSquareFoot(4)).toBe(9);
+    expect(plantsPerSquareFoot(5)).toBe(9);
+  });
+
+  it("returns 4 for 6–11 inch spacing", () => {
+    expect(plantsPerSquareFoot(6)).toBe(4);
+    expect(plantsPerSquareFoot(8)).toBe(4);
+    expect(plantsPerSquareFoot(11)).toBe(4);
+  });
+
+  it("returns 1 for 12-inch and wider spacing", () => {
+    expect(plantsPerSquareFoot(12)).toBe(1);
+    expect(plantsPerSquareFoot(18)).toBe(1);
+    expect(plantsPerSquareFoot(36)).toBe(1);
+  });
+
+  it("matches canonical SFG densities for known plants", () => {
+    // tomato (24"), lettuce (8"), bush bean (4"), radish (2")
+    expect(plantsPerSquareFoot(24)).toBe(1);
+    expect(plantsPerSquareFoot(8)).toBe(4);
+    expect(plantsPerSquareFoot(4)).toBe(9);
+    expect(plantsPerSquareFoot(2)).toBe(16);
+  });
+});
+
+describe("subGridSide", () => {
+  it("returns the integer square root of capacity", () => {
+    expect(subGridSide(1)).toBe(1);
+    expect(subGridSide(4)).toBe(2);
+    expect(subGridSide(9)).toBe(3);
+    expect(subGridSide(16)).toBe(4);
+  });
+});

--- a/src/lib/spacing.ts
+++ b/src/lib/spacing.ts
@@ -1,0 +1,10 @@
+export function plantsPerSquareFoot(spacingInches: number): number {
+  if (spacingInches <= 3) return 16;
+  if (spacingInches <= 5) return 9;
+  if (spacingInches <= 11) return 4;
+  return 1;
+}
+
+export function subGridSide(capacity: number): number {
+  return Math.round(Math.sqrt(capacity));
+}

--- a/src/store.test.ts
+++ b/src/store.test.ts
@@ -1,0 +1,122 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { useGarden } from "./store";
+
+describe("placePlant capacity enforcement", () => {
+  let bedId: string;
+
+  beforeEach(() => {
+    useGarden.getState().resetGarden();
+    bedId = useGarden.getState().addBed({
+      name: "Test bed",
+      widthFt: 4,
+      lengthFt: 4,
+      sun: "full",
+    });
+  });
+
+  it("places one tomato (capacity 1) successfully", () => {
+    useGarden.getState().placePlant(bedId, "tomato", 0, 0);
+    expect(useGarden.getState().placements).toHaveLength(1);
+  });
+
+  it("rejects a second tomato in the same cell (over capacity)", () => {
+    useGarden.getState().placePlant(bedId, "tomato", 0, 0);
+    useGarden.getState().placePlant(bedId, "tomato", 0, 0);
+    expect(useGarden.getState().placements).toHaveLength(1);
+  });
+
+  it("allows up to 4 lettuces in one cell (6-inch spacing → capacity 4)", () => {
+    for (let i = 0; i < 4; i++) {
+      useGarden.getState().placePlant(bedId, "lettuce", 0, 0);
+    }
+    expect(useGarden.getState().placements).toHaveLength(4);
+  });
+
+  it("rejects a 5th lettuce in the same cell", () => {
+    for (let i = 0; i < 5; i++) {
+      useGarden.getState().placePlant(bedId, "lettuce", 0, 0);
+    }
+    expect(useGarden.getState().placements).toHaveLength(4);
+  });
+
+  it("allows up to 16 radishes in one cell (2-inch spacing → capacity 16)", () => {
+    for (let i = 0; i < 16; i++) {
+      useGarden.getState().placePlant(bedId, "radish", 0, 0);
+    }
+    expect(useGarden.getState().placements).toHaveLength(16);
+  });
+
+  it("rejects a different species in a partially-filled cell", () => {
+    useGarden.getState().placePlant(bedId, "lettuce", 0, 0);
+    useGarden.getState().placePlant(bedId, "tomato", 0, 0);
+    const placements = useGarden.getState().placements;
+    expect(placements).toHaveLength(1);
+    expect(placements[0].plantId).toBe("lettuce");
+  });
+
+  it("ignores a plant ID that doesn't exist", () => {
+    useGarden.getState().placePlant(bedId, "nonexistent-plant", 0, 0);
+    expect(useGarden.getState().placements).toHaveLength(0);
+  });
+});
+
+describe("movePlacement capacity enforcement", () => {
+  let bedId: string;
+
+  beforeEach(() => {
+    useGarden.getState().resetGarden();
+    bedId = useGarden.getState().addBed({
+      name: "Test bed",
+      widthFt: 4,
+      lengthFt: 4,
+      sun: "full",
+    });
+  });
+
+  it("allows moving a placement back to its own cell (self-drop)", () => {
+    useGarden.getState().placePlant(bedId, "tomato", 0, 0);
+    const placementId = useGarden.getState().placements[0].id;
+    useGarden.getState().movePlacement(placementId, bedId, 0, 0);
+    expect(useGarden.getState().placements[0].row).toBe(0);
+    expect(useGarden.getState().placements[0].col).toBe(0);
+  });
+
+  it("rejects moving a tomato onto a cell occupied by lettuce", () => {
+    useGarden.getState().placePlant(bedId, "tomato", 0, 0);
+    useGarden.getState().placePlant(bedId, "lettuce", 1, 1);
+    const tomatoId = useGarden
+      .getState()
+      .placements.find((p) => p.plantId === "tomato")!.id;
+    useGarden.getState().movePlacement(tomatoId, bedId, 1, 1);
+    const tomato = useGarden.getState().placements.find((p) => p.id === tomatoId)!;
+    expect(tomato.row).toBe(0);
+    expect(tomato.col).toBe(0);
+  });
+
+  it("allows moving a lettuce into a cell that has room for more lettuce", () => {
+    useGarden.getState().placePlant(bedId, "lettuce", 0, 0);
+    useGarden.getState().placePlant(bedId, "lettuce", 0, 0);
+    useGarden.getState().placePlant(bedId, "lettuce", 1, 1);
+    const movingId = useGarden
+      .getState()
+      .placements.filter((p) => p.row === 1 && p.col === 1)[0].id;
+    useGarden.getState().movePlacement(movingId, bedId, 0, 0);
+    expect(
+      useGarden.getState().placements.filter((p) => p.row === 0 && p.col === 0),
+    ).toHaveLength(3);
+  });
+
+  it("rejects moving a lettuce into a cell already at capacity", () => {
+    for (let i = 0; i < 4; i++) {
+      useGarden.getState().placePlant(bedId, "lettuce", 0, 0);
+    }
+    useGarden.getState().placePlant(bedId, "lettuce", 1, 1);
+    const movingId = useGarden
+      .getState()
+      .placements.filter((p) => p.row === 1 && p.col === 1)[0].id;
+    useGarden.getState().movePlacement(movingId, bedId, 0, 0);
+    const moving = useGarden.getState().placements.find((p) => p.id === movingId)!;
+    expect(moving.row).toBe(1);
+    expect(moving.col).toBe(1);
+  });
+});

--- a/src/store.ts
+++ b/src/store.ts
@@ -1,6 +1,8 @@
 import { create } from "zustand";
 import { persist } from "zustand/middleware";
 import type { Bed, GardenState, Location, Placement } from "./types";
+import { PLANT_BY_ID } from "./data/plants";
+import { plantsPerSquareFoot } from "./lib/spacing";
 
 export const STORAGE_KEY = "garden-planner-state-v1";
 
@@ -47,10 +49,15 @@ export const useGarden = create<GardenState & Actions>()(
         })),
       placePlant: (bedId, plantId, row, col) =>
         set((s) => {
-          const existing = s.placements.find(
+          const plant = PLANT_BY_ID.get(plantId);
+          if (!plant) return s;
+          const occupants = s.placements.filter(
             (p) => p.bedId === bedId && p.row === row && p.col === col,
           );
-          if (existing) return s;
+          // Cell already holds a different species — reject.
+          if (occupants.length > 0 && occupants[0].plantId !== plantId) return s;
+          // Cell at capacity for this plant's spacing — reject.
+          if (occupants.length >= plantsPerSquareFoot(plant.spacingInches)) return s;
           const placement: Placement = {
             id: uid(),
             bedId,
@@ -63,14 +70,21 @@ export const useGarden = create<GardenState & Actions>()(
         }),
       movePlacement: (placementId, bedId, row, col) =>
         set((s) => {
-          const collision = s.placements.find(
+          const moving = s.placements.find((p) => p.id === placementId);
+          if (!moving) return s;
+          const plant = PLANT_BY_ID.get(moving.plantId);
+          if (!plant) return s;
+          const occupants = s.placements.filter(
             (p) =>
               p.id !== placementId &&
               p.bedId === bedId &&
               p.row === row &&
               p.col === col,
           );
-          if (collision) return s;
+          // Different species in target cell — reject.
+          if (occupants.length > 0 && occupants[0].plantId !== moving.plantId) return s;
+          // Target cell at capacity — reject.
+          if (occupants.length >= plantsPerSquareFoot(plant.spacingInches)) return s;
           return {
             placements: s.placements.map((p) =>
               p.id === placementId ? { ...p, bedId, row, col } : p,

--- a/src/test-setup.ts
+++ b/src/test-setup.ts
@@ -1,0 +1,19 @@
+// Provide a no-op localStorage so Zustand's persist middleware doesn't
+// log warnings under Node during tests.
+const memoryStorage = (() => {
+  const store = new Map<string, string>();
+  return {
+    getItem: (k: string) => store.get(k) ?? null,
+    setItem: (k: string, v: string) => void store.set(k, v),
+    removeItem: (k: string) => void store.delete(k),
+    clear: () => store.clear(),
+    key: (i: number) => Array.from(store.keys())[i] ?? null,
+    get length() {
+      return store.size;
+    },
+  };
+})();
+
+if (typeof globalThis.localStorage === "undefined") {
+  Object.defineProperty(globalThis, "localStorage", { value: memoryStorage });
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,3 +1,4 @@
+/// <reference types="vitest" />
 import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
 
@@ -9,4 +10,7 @@ export default defineConfig({
     strictPort: true,
   },
   envPrefix: ["VITE_", "TAURI_"],
+  test: {
+    setupFiles: ["./src/test-setup.ts"],
+  },
 });


### PR DESCRIPTION
## Summary

Closes #2. Each 1×1-ft cell can now hold up to 16 plants of the same species based on real square-foot gardening density.

| Plant spacing | Plants per sq ft | Sub-grid | Examples |
|---|---|---|---|
| ≤3"  | 16 | 4×4 | radish |
| 4–5" | 9  | 3×3 | bush bean, beet |
| 6–11"| 4  | 2×2 | lettuce, spinach, parsley |
| ≥12" | 1  | 1×1 | tomato, pepper, broccoli |

## Implementation

- **`src/lib/spacing.ts`** — `plantsPerSquareFoot(spacingInches)` and `subGridSide(capacity)` as pure helpers. The issue suggested adding `plantsPerSquareFoot` as a field on `Plant`; I made it a derived helper instead so spacing remains the single source of truth and no plant data needs to be touched.
- **`store.ts`** — `placePlant` and `movePlacement` now allow multiple same-species placements in a single `(bed, row, col)` up to capacity, and reject mixed species in one cell. The store consults `PLANT_BY_ID` for spacing.
- **`BedCanvas.tsx`** — `GridCell` collects all occupants in a cell, sorts them stably by id, and renders a sub-grid (1×1 / 2×2 / 3×3 / 4×4) sized to the occupying plant's capacity. Empty slots remain droppable; cell title shows `"N/capacity Plant Name"`; drop hover ring turns red when at capacity.
- **`companions.allIssues`** — dedups by `(plantA, plantB, bedId)` so a cell with 4 lettuces next to a tomato no longer produces 4 identical "Tomato + Lettuce" rows in the IssuesPanel. Original placement IDs are preserved on the first issue of each pair.

## Tests

- **`spacing.test.ts`** — 6 tests covering all density buckets and the canonical SFG densities for tomato/lettuce/bush bean/radish
- **`companions.test.ts`** (new) — 8 tests covering `verdictBetween`, `neighborsOf` (including cross-bed exclusion), and the `allIssues` dedup invariants (single bed stacking, cross-bed independence, same-plant-same-cell silence)

`npm test`: 41/41 pass. `npm run build`: clean. `tsc --noEmit`: clean.

## Test plan

- [ ] Drag lettuce onto an empty cell — should render in a 2×2 sub-grid with one slot filled
- [ ] Drag 3 more lettuces onto the same cell — fills out to 2×2; 5th attempt rejected (drop ring red)
- [ ] Try to drop a tomato onto a partially-filled lettuce cell — rejected
- [ ] Drag radish onto an empty cell — 4×4 sub-grid; can fill all 16 slots
- [ ] Place 4 lettuces in cell A and 1 tomato in adjacent cell B — IssuesPanel shows "Tomato + Lettuce" exactly once, not 4 times
- [ ] Right-click any individual plant instance — only that one is removed; siblings remain in place
- [ ] Drag one lettuce out of a 4-cell to an empty cell — moves cleanly; remaining 3 lettuces re-flow

🤖 Generated with [Claude Code](https://claude.ai/claude-code)